### PR TITLE
BLD: pinning tensorflow version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # mmvec changelog
 
+## Version 1.0.3 (2019-12-12)
+# Enhancements
+ - Tensorflow is now pinned to any version below 2.0 in [#112](https://github.com/biocore/mmvec/pull/112)
+ - Learning rate defaults have been fixed to `1e-5` in [#110](https://github.com/biocore/mmvec/pull/110)
+
+# Bug fixes
+ - Inputs are now expected to be metabolites x microbes in heatmaps [#100](https://github.com/biocore/mmvec/pull/100)
+
 ## Version 1.0.2 (2019-10-18)
 # Bug fixes
  - Inputs are now expected to be metabolites x microbes in heatmaps [#100](https://github.com/biocore/mmvec/pull/100)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MMvec can be installed via pypi as follows
 pip install mmvec
 ```
 
-If you are planning on using GPUs, be sure to `pip install tensorflow-gpu`.
+If you are planning on using GPUs, be sure to `pip install tensorflow-gpu <= 1.14.0`.
 
 MMvec can also be installed via conda as follows
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(name='mmvec',
           'scikit-bio >= 0.5.1',
           'seaborn',
           'tqdm',
-          'tensorflow'
+          'tensorflow <= 1.14.0'
       ],
       classifiers=classifiers,
       entry_points={


### PR DESCRIPTION
The setup.py now explicitly requires the TF is pinned below 1.14.0

TODO
- Update changelog
- Re-release pypi version to make this more explicit
